### PR TITLE
Remove filter format sorting to simplify config exports

### DIFF
--- a/PATCHES.md
+++ b/PATCHES.md
@@ -1,14 +1,6 @@
-- Cache rebuild ignores multisite directories:
-https://www.drupal.org/files/issues/2018-07-11/specify_sitepath_cache_rebuild_extension_discovery-2985199-3.patch
-
-- Taxonomy Term field with Rendered Entity formatter breaks migration:
-https://www.drupal.org/files/issues/2018-08-21/drupal-map_taxonomy_term_formatter_rendered_entity-2993927-1.patch
-
-- Add the migration from D7 Picture to Responsive Image:
-https://www.drupal.org/files/issues/2018-08-17/drupal-responsive_image_migration-2993367-2.patch
-
-- Issue #1178342: Allow contributed modules to alter the format_date() function result:
-https://www.drupal.org/files/issues/2018-08-28/drupal-format_date_alter-1178342-156-8.6.x.patch
-
-- Map menus when migrating content type settings:
-https://www.drupal.org/files/issues/2018-09-11/drupal-map_menus_migrate_content_types-2998875-1.patch
+* [Issue #2985199 patch 3: Cache rebuild ignores multisite directories](https://www.drupal.org/files/issues/2018-07-11/specify_sitepath_cache_rebuild_extension_discovery-2985199-3.patch)
+* [Issue #2993927 patch 1: Taxonomy Term field with Rendered Entity formatter breaks migration](https://www.drupal.org/files/issues/2018-08-21/drupal-map_taxonomy_term_formatter_rendered_entity-2993927-1.patch)
+* [Issue #2993367 patch 2: Add the migration from D7 Picture to Responsive Image](https://www.drupal.org/files/issues/2018-08-17/drupal-responsive_image_migration-2993367-2.patch)
+* [Issue #1178342 patch 156: Allow contributed modules to alter the format_date() function result](https://www.drupal.org/files/issues/2018-08-28/drupal-format_date_alter-1178342-156-8.6.x.patch)
+* [Issue #2998875 patch 1: Map menus when migrating content type settings](https://www.drupal.org/files/issues/2018-09-11/drupal-map_menus_migrate_content_types-2998875-1.patch)
+* [Issue #3017054 patch 1: Remove filter format sorting to simplify config exports](https://www.drupal.org/files/issues/2018-11-29/3017054-remove-filters-sort.patch)

--- a/PATCHES.md
+++ b/PATCHES.md
@@ -3,3 +3,4 @@
 * [Issue #2993367 patch 2: Add the migration from D7 Picture to Responsive Image](https://www.drupal.org/files/issues/2018-08-17/drupal-responsive_image_migration-2993367-2.patch)
 * [Issue #1178342 patch 156: Allow contributed modules to alter the format_date() function result](https://www.drupal.org/files/issues/2018-08-28/drupal-format_date_alter-1178342-156-8.6.x.patch)
 * [Issue #2998875 patch 1: Map menus when migrating content type settings](https://www.drupal.org/files/issues/2018-09-11/drupal-map_menus_migrate_content_types-2998875-1.patch)
+* [Issue #3017054 patch 1: Remove filter format sorting to simplify config exports](https://www.drupal.org/files/issues/2018-11-29/3017054-remove-filters-sort.patch)

--- a/modules/filter/config/install/filter.format.plain_text.yml
+++ b/modules/filter/config/install/filter.format.plain_text.yml
@@ -16,6 +16,13 @@ filters:
     status: true
     weight: -10
     settings: {  }
+  # Convert linebreaks into paragraphs.
+  filter_autop:
+    id: filter_autop
+    provider: filter
+    status: true
+    weight: 0
+    settings: {  }
   # Convert URLs into links.
   filter_url:
     id: filter_url
@@ -24,10 +31,3 @@ filters:
     weight: 0
     settings:
       filter_url_length: 72
-  # Convert linebreaks into paragraphs.
-  filter_autop:
-    id: filter_autop
-    provider: filter
-    status: true
-    weight: 0
-    settings: {  }

--- a/modules/filter/src/Entity/FilterFormat.php
+++ b/modules/filter/src/Entity/FilterFormat.php
@@ -456,7 +456,12 @@ class FilterFormat extends ConfigEntityBase implements FilterFormatInterface, En
     $this->filterCollection->sort();
     $sorted_filters = [];
     foreach ($this->filterCollection->getInstanceIds() as $sorted_id) {
-      $sorted_filters[$sorted_id] = $this->filters[$sorted_id];
+      // When new modules are installed, new filter plugins may be available but
+      // may not be saved to the filter format yet. Only sort filters that are
+      // actually set on this format.
+      if (isset($this->filters[$sorted_id])) {
+        $sorted_filters[$sorted_id] = $this->filters[$sorted_id];
+      }
     }
     $this->filters = $sorted_filters;
   }

--- a/modules/filter/src/Entity/FilterFormat.php
+++ b/modules/filter/src/Entity/FilterFormat.php
@@ -141,6 +141,7 @@ class FilterFormat extends ConfigEntityBase implements FilterFormatInterface, En
   public function filters($instance_id = NULL) {
     if (!isset($this->filterCollection)) {
       $this->filterCollection = new FilterPluginCollection(\Drupal::service('plugin.manager.filter'), $this->filters);
+      $this->sortFilters();
     }
     if (isset($instance_id)) {
       return $this->filterCollection->get($instance_id);
@@ -162,6 +163,8 @@ class FilterFormat extends ConfigEntityBase implements FilterFormatInterface, En
     $this->filters[$instance_id] = $configuration;
     if (isset($this->filterCollection)) {
       $this->filterCollection->setInstanceConfiguration($instance_id, $configuration);
+
+      $this->sortFilters();
     }
     return $this;
   }
@@ -433,6 +436,29 @@ class FilterFormat extends ConfigEntityBase implements FilterFormatInterface, En
     if (isset($this->filters[$instance->getPluginId()])) {
       parent::calculatePluginDependencies($instance);
     }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function get($property_name) {
+    if ($property_name == 'filters') {
+      $this->filters();
+      return $this->filters;
+    }
+    return parent::get($property_name);
+  }
+
+  /**
+   * Sort filters in the underlying filter collection and the filters property.
+   */
+  protected function sortFilters(): void {
+    $this->filterCollection->sort();
+    $sorted_filters = [];
+    foreach ($this->filterCollection->getInstanceIds() as $sorted_id) {
+      $sorted_filters[$sorted_id] = $this->filters[$sorted_id];
+    }
+    $this->filters = $sorted_filters;
   }
 
 }

--- a/modules/filter/src/Entity/FilterFormat.php
+++ b/modules/filter/src/Entity/FilterFormat.php
@@ -141,7 +141,6 @@ class FilterFormat extends ConfigEntityBase implements FilterFormatInterface, En
   public function filters($instance_id = NULL) {
     if (!isset($this->filterCollection)) {
       $this->filterCollection = new FilterPluginCollection(\Drupal::service('plugin.manager.filter'), $this->filters);
-      $this->filterCollection->sort();
     }
     if (isset($instance_id)) {
       return $this->filterCollection->get($instance_id);
@@ -201,9 +200,6 @@ class FilterFormat extends ConfigEntityBase implements FilterFormatInterface, En
    * {@inheritdoc}
    */
   public function preSave(EntityStorageInterface $storage) {
-    // Ensure the filters have been sorted before saving.
-    $this->filters()->sort();
-
     parent::preSave($storage);
 
     $this->name = trim($this->label());

--- a/modules/filter/tests/src/Kernel/Migrate/d7/MigrateFilterFormatTest.php
+++ b/modules/filter/tests/src/Kernel/Migrate/d7/MigrateFilterFormatTest.php
@@ -44,7 +44,6 @@ class MigrateFilterFormatTest extends MigrateDrupal7TestBase {
     $entity = FilterFormat::load($id);
     $this->assertInstanceOf(FilterFormatInterface::class, $entity);
     $this->assertSame($label, $entity->label());
-    // get('filters') will return enabled filters only, not all of them.
     $this->assertSame(array_keys($enabled_filters), array_keys($entity->get('filters')));
     $this->assertSame($weight, $entity->get('weight'));
     foreach ($entity->get('filters') as $filter_id => $filter) {
@@ -56,9 +55,9 @@ class MigrateFilterFormatTest extends MigrateDrupal7TestBase {
    * Tests the Drupal 7 filter format to Drupal 8 migration.
    */
   public function testFilterFormat() {
-    $this->assertEntity('custom_text_format', 'Custom Text format', ['filter_autop' => 0, 'filter_html' => -10], 0);
-    $this->assertEntity('filtered_html', 'Filtered HTML', ['filter_autop' => 2, 'filter_html' => 1, 'filter_htmlcorrector' => 10, 'filter_url' => 0], 0);
-    $this->assertEntity('full_html', 'Full HTML', ['filter_autop' => 1, 'filter_htmlcorrector' => 10, 'filter_url' => 0], 1);
+    $this->assertEntity('custom_text_format', 'Custom Text format', ['filter_html' => -10, 'filter_autop' => 0], 0);
+    $this->assertEntity('filtered_html', 'Filtered HTML', ['filter_url' => 0, 'filter_html' => 1, 'filter_autop' => 2, 'filter_htmlcorrector' => 10], 0);
+    $this->assertEntity('full_html', 'Full HTML', ['filter_url' => 0, 'filter_autop' => 1, 'filter_htmlcorrector' => 10], 1);
     $this->assertEntity('plain_text', 'Plain text', ['filter_html_escape' => 0, 'filter_url' => 1, 'filter_autop' => 2], 10);
     // This assertion covers issue #2555089. Drupal 7 formats are identified
     // by machine names, so migrated formats should be merged into existing


### PR DESCRIPTION
https://www.drupal.org/project/drupal/issues/3017054

While this is a good fix upstream I think, I just tried it with a fresh database and it's not fixing the config export issue I thought it did. Hold off on merging for now.