### PR TITLE
BO-665 Race condition

### DIFF
--- a/PATCHES.md
+++ b/PATCHES.md
@@ -4,3 +4,4 @@
 * [Issue #2998875 patch 1: Map menus when migrating content type settings](https://www.drupal.org/files/issues/2018-09-11/drupal-map_menus_migrate_content_types-2998875-1.patch)
 * [Issue #3017054 patch 10: Remove filter format sorting to simplify config exports](https://www.drupal.org/files/issues/2018-12-03/3017054-14-force-filters-sort.patch)
 * [Issue #3022910 patch 2: Prevent migrated files from having an incorrect value at file_managed.filename](https://www.drupal.org/files/issues/2018-12-28/drupal-file_entity_filename-3022910-1.patch)
+* [Issue #2966607 patch 127: Invalidating 'node_list' and other broad cache tags early in a transaction severely increases lock wait time and probability of deadlock](https://www.drupal.org/files/issues/2019-09-10/2966607-127.patch)

--- a/lib/Drupal/Core/Cache/CacheTagsChecksumInterface.php
+++ b/lib/Drupal/Core/Cache/CacheTagsChecksumInterface.php
@@ -19,6 +19,23 @@ namespace Drupal\Core\Cache;
 interface CacheTagsChecksumInterface {
 
   /**
+   * The invalid checksum returned if a database transaction is in progress.
+   *
+   * Every cache backend SHOULD detect this and not write cache items that have
+   * this checksum. Not detecting this would not yield incorrect cache reads,
+   * but would be a useless write.
+   *
+   * While a database transaction is progress, cache tag invalidations are
+   * delayed to occur just before the commit, to allow:
+   * - deadlock potential to be minimized, since semaphores to avoid concurrent
+   *   writes can be acquired for the shortest period possible
+   * - Non-database-based implementations of this service can delay tag
+   *   invalidations until the transaction is committed to avoid
+   *   race conditions.
+   */
+  const INVALID_CHECKSUM_WHILE_IN_TRANSACTION = -1;
+
+  /**
    * Returns the sum total of validations for a given set of tags.
    *
    * Called by a backend when storing a cache item.

--- a/lib/Drupal/Core/Cache/CacheTagsChecksumTrait.php
+++ b/lib/Drupal/Core/Cache/CacheTagsChecksumTrait.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace Drupal\Core\Cache;
+
+/**
+ * A trait for cache tag checksum implementations.
+ *
+ * Handles delayed cache tag invalidations.
+ */
+trait CacheTagsChecksumTrait {
+
+  /**
+   * A list of tags that have already been invalidated in this request.
+   *
+   * Used to prevent the invalidation of the same cache tag multiple times.
+   *
+   * @var bool[]
+   */
+  protected $invalidatedTags = [];
+
+  /**
+   * The set of cache tags whose invalidation is delayed.
+   *
+   * @var string[]
+   */
+  protected $delayedTags = [];
+
+  /**
+   * Contains already loaded tag invalidation counts from the storage.
+   *
+   * @var int[]
+   */
+  protected $tagCache = [];
+
+  /**
+   * Callback to be invoked just after a database transaction gets committed.
+   *
+   * Executes all delayed tag invalidations.
+   *
+   * @param bool $success
+   *   Whether or not the transaction was successful.
+   */
+  public function rootTransactionEndCallback($success) {
+    if ($success) {
+      $this->doInvalidateTags($this->delayedTags);
+    }
+    $this->delayedTags = [];
+  }
+
+  /**
+   * Implements \Drupal\Core\Cache\CacheTagsChecksumInterface::invalidateTags()
+   */
+  public function invalidateTags(array $tags) {
+    // Only invalidate tags once per request unless they are written again.
+    foreach ($tags as $key => $tag) {
+      if (isset($this->invalidatedTags[$tag])) {
+        unset($tags[$key]);
+      }
+      else {
+        $this->invalidatedTags[$tag] = TRUE;
+        unset($this->tagCache[$tag]);
+      }
+    }
+    if (!$tags) {
+      return;
+    }
+
+    $in_transaction = $this->getDatabaseConnection()->inTransaction();
+    if ($in_transaction) {
+      if (empty($this->delayedTags)) {
+        $this->getDatabaseConnection()->addRootTransactionEndCallback([$this, 'rootTransactionEndCallback']);
+      }
+      $this->delayedTags = Cache::mergeTags($this->delayedTags, $tags);
+    }
+    else {
+      $this->doInvalidateTags($tags);
+    }
+  }
+
+  /**
+   * Implements \Drupal\Core\Cache\CacheTagsChecksumInterface::getCurrentChecksum()
+   */
+  public function getCurrentChecksum(array $tags) {
+    // Any cache writes in this request containing cache tags whose invalidation
+    // has been delayed due to an in-progress transaction must not be read by
+    // any other request, so use a nonsensical checksum which will cause any
+    // written cache items to be ignored.
+    if (!empty(array_intersect($tags, $this->delayedTags))) {
+      return CacheTagsChecksumInterface::INVALID_CHECKSUM_WHILE_IN_TRANSACTION;
+    }
+
+    // Remove tags that were already invalidated during this request from the
+    // static caches so that another invalidation can occur later in the same
+    // request. Without that, written cache items would not be invalidated
+    // correctly.
+    foreach ($tags as $tag) {
+      unset($this->invalidatedTags[$tag]);
+    }
+    return $this->calculateChecksum($tags);
+  }
+
+  /**
+   * Implements \Drupal\Core\Cache\CacheTagsChecksumInterface::isValid()
+   */
+  public function isValid($checksum, array $tags) {
+    // Any cache reads in this request involving cache tags whose invalidation
+    // has been delayed due to an in-progress transaction are not allowed to use
+    // data stored in cache; it must be assumed to be stale. This forces those
+    // results to be computed instead. Together with the logic in
+    // ::getCurrentChecksum(), it also prevents that computed data from being
+    // written to the cache.
+    if (!empty(array_intersect($tags, $this->delayedTags))) {
+      return FALSE;
+    }
+
+    return $checksum == $this->calculateChecksum($tags);
+  }
+
+  /**
+   * Calculates the current checksum for a given set of tags.
+   *
+   * @param string[] $tags
+   *   The array of tags to calculate the checksum for.
+   *
+   * @return int
+   *   The calculated checksum.
+   */
+  protected function calculateChecksum(array $tags) {
+    $checksum = 0;
+
+    $query_tags = array_diff($tags, array_keys($this->tagCache));
+    if ($query_tags) {
+      $tag_invalidations = $this->getTagInvalidationCounts($query_tags);
+      $this->tagCache += $tag_invalidations;
+      // Fill static cache with empty objects for tags not found in the storage.
+      $this->tagCache += array_fill_keys(array_diff($query_tags, array_keys($tag_invalidations)), 0);
+    }
+
+    foreach ($tags as $tag) {
+      $checksum += $this->tagCache[$tag];
+    }
+
+    return $checksum;
+  }
+
+  /**
+   * Implements \Drupal\Core\Cache\CacheTagsChecksumInterface::reset()
+   */
+  public function reset() {
+    $this->tagCache = [];
+    $this->invalidatedTags = [];
+  }
+
+  /**
+   * Fetches invalidation counts for cache tags.
+   *
+   * @param string[] $tags
+   *   The list of tags to fetch invalidations for.
+   *
+   * @return int[]
+   *   List of invalidation counts keyed by the respective cache tag.
+   */
+  abstract protected function getTagInvalidationCounts(array $tags);
+
+  /**
+   * Returns the database connection.
+   *
+   * @return \Drupal\Core\Database\Connection
+   *   The database connection.
+   */
+  abstract protected function getDatabaseConnection();
+
+  /**
+   * Marks cache items with any of the specified tags as invalid.
+   *
+   * @param string[] $tags
+   *   The set of tags for which to invalidate cache items.
+   */
+  abstract protected function doInvalidateTags(array $tags);
+
+}

--- a/lib/Drupal/Core/Database/Connection.php
+++ b/lib/Drupal/Core/Database/Connection.php
@@ -155,6 +155,13 @@ abstract class Connection {
   protected $escapedAliases = [];
 
   /**
+   * Post-root (non-nested) transaction commit callbacks.
+   *
+   * @var callable[]
+   */
+  protected $rootTransactionEndCallbacks = [];
+
+  /**
    * Constructs a Connection object.
    *
    * @param \PDO $connection
@@ -1137,6 +1144,14 @@ abstract class Connection {
         $rolled_back_other_active_savepoints = TRUE;
       }
     }
+
+    // Notify the callbacks about the rollback.
+    $callbacks = $this->rootTransactionEndCallbacks;
+    $this->rootTransactionEndCallbacks = [];
+    foreach ($callbacks as $callback) {
+      call_user_func($callback, FALSE);
+    }
+
     $this->connection->rollBack();
     if ($rolled_back_other_active_savepoints) {
       throw new TransactionOutOfOrderException();
@@ -1206,7 +1221,37 @@ abstract class Connection {
   }
 
   /**
-   * Internal function: commit all the transaction layers that can commit.
+   * Adds a root transaction end callback.
+   *
+   * These callbacks are invoked immediately after the transaction has been
+   * committed.
+   *
+   * It can for example be used to avoid deadlocks on write-heavy tables that
+   * do not need to be part of the transaction, like cache tag invalidations.
+   *
+   * Another use case is that services using alternative backends like Redis and
+   * Memcache cache implementations can replicate the transaction-behavior of
+   * the database cache backend and avoid race conditions.
+   *
+   * An argument is passed to the callbacks that indicates whether the
+   * transaction was successful or not.
+   *
+   * @param callable $callback
+   *   The callback to invoke.
+   *
+   * @see \Drupal\Core\Database\Connection::doCommit()
+   */
+  public function addRootTransactionEndCallback(callable $callback) {
+    if (!$this->transactionLayers) {
+      throw new \LogicException('Root transaction end callbacks can only be added when there is an active transaction.');
+    }
+    $this->rootTransactionEndCallbacks[] = $callback;
+  }
+
+  /**
+   * Commit all the transaction layers that can commit.
+   *
+   * @internal
    */
   protected function popCommittableTransactions() {
     // Commit all the committable layers.
@@ -1219,13 +1264,31 @@ abstract class Connection {
       // If there are no more layers left then we should commit.
       unset($this->transactionLayers[$name]);
       if (empty($this->transactionLayers)) {
-        if (!$this->connection->commit()) {
-          throw new TransactionCommitFailedException();
-        }
+        $this->doCommit();
       }
       else {
         $this->query('RELEASE SAVEPOINT ' . $name);
       }
+    }
+  }
+
+  /**
+   * Do the actual commit, invoke post-commit callbacks.
+   *
+   * @internal
+   */
+  protected function doCommit() {
+    $success = $this->connection->commit();
+    if (!empty($this->rootTransactionEndCallbacks)) {
+      $callbacks = $this->rootTransactionEndCallbacks;
+      $this->rootTransactionEndCallbacks = [];
+      foreach ($callbacks as $callback) {
+        call_user_func($callback, $success);
+      }
+    }
+
+    if (!$success) {
+      throw new TransactionCommitFailedException();
     }
   }
 

--- a/lib/Drupal/Core/Database/Driver/mysql/Connection.php
+++ b/lib/Drupal/Core/Database/Driver/mysql/Connection.php
@@ -7,7 +7,6 @@ use Drupal\Core\Database\DatabaseExceptionWrapper;
 
 use Drupal\Core\Database\Database;
 use Drupal\Core\Database\DatabaseNotFoundException;
-use Drupal\Core\Database\TransactionCommitFailedException;
 use Drupal\Core\Database\DatabaseException;
 use Drupal\Core\Database\Connection as DatabaseConnection;
 use Drupal\Component\Utility\Unicode;
@@ -637,9 +636,7 @@ class Connection extends DatabaseConnection {
       // If there are no more layers left then we should commit.
       unset($this->transactionLayers[$name]);
       if (empty($this->transactionLayers)) {
-        if (!$this->connection->commit()) {
-          throw new TransactionCommitFailedException();
-        }
+        $this->doCommit();
       }
       else {
         // Attempt to release this savepoint in the standard way.
@@ -660,7 +657,7 @@ class Connection extends DatabaseConnection {
             $this->transactionLayers = [];
             // We also have to explain to PDO that the transaction stack has
             // been cleaned-up.
-            $this->connection->commit();
+            $this->doCommit();
           }
           else {
             throw $e;

--- a/modules/migrate_drupal_ui/tests/src/Functional/d6/files/core/modules/system/tests/modules/database_statement_monitoring_test/database_statement_monitoring_test.info.yml
+++ b/modules/migrate_drupal_ui/tests/src/Functional/d6/files/core/modules/system/tests/modules/database_statement_monitoring_test/database_statement_monitoring_test.info.yml
@@ -1,0 +1,6 @@
+name: 'Database Statement Monitoring Test'
+type: module
+description: 'Support module for Database layer tests that need to monitor executed database statements.'
+core: 8.x
+package: Testing
+version: VERSION

--- a/modules/migrate_drupal_ui/tests/src/Functional/d6/files/core/modules/system/tests/modules/database_statement_monitoring_test/src/LoggedStatementsTrait.php
+++ b/modules/migrate_drupal_ui/tests/src/Functional/d6/files/core/modules/system/tests/modules/database_statement_monitoring_test/src/LoggedStatementsTrait.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Drupal\database_statement_monitoring_test;
+
+/**
+ * Trait for Connection classes that can store logged statements.
+ */
+trait LoggedStatementsTrait {
+
+  /**
+   * Logged statements.
+   *
+   * @var string[]
+   */
+  protected $loggedStatements;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query($query, array $args = [], $options = []) {
+    // Log the query if it is a string, can receive statement objects e.g
+    // in the pgsql driver. These are hard to log as the table name has already
+    // been replaced.
+    if (is_string($query)) {
+      $stringified_args = array_map(function ($v) {
+        return is_array($v) ? implode(',', $v) : $v;
+      }, $args);
+      $this->loggedStatements[] = str_replace(array_keys($stringified_args), array_values($stringified_args), $query);
+    }
+    return parent::query($query, $args, $options);
+  }
+
+  /**
+   * Resets logged statements.
+   *
+   * @return $this
+   */
+  public function resetLoggedStatements() {
+    $this->loggedStatements = [];
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDriverClass($class) {
+    // Override because the base class uses reflection to determine namespace
+    // based on object, which would break.
+    $namespace = (new \ReflectionClass(get_parent_class($this)))->getNamespaceName();
+    $driver_class = $namespace . '\\' . $class;
+    return class_exists($driver_class) ? $driver_class : $class;
+  }
+
+  /**
+   * Returns the executed queries.
+   *
+   * @return string[]
+   */
+  public function getLoggedStatements() {
+    return $this->loggedStatements;
+  }
+
+}

--- a/modules/migrate_drupal_ui/tests/src/Functional/d6/files/core/modules/system/tests/modules/database_statement_monitoring_test/src/mysql/Connection.php
+++ b/modules/migrate_drupal_ui/tests/src/Functional/d6/files/core/modules/system/tests/modules/database_statement_monitoring_test/src/mysql/Connection.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Drupal\database_statement_monitoring_test\mysql;
+
+use Drupal\Core\Database\Driver\mysql\Connection as BaseConnection;
+use Drupal\database_statement_monitoring_test\LoggedStatementsTrait;
+
+/**
+ * MySQL Connection class that can log executed queries.
+ */
+class Connection extends BaseConnection {
+  use LoggedStatementsTrait;
+
+}

--- a/modules/migrate_drupal_ui/tests/src/Functional/d6/files/core/modules/system/tests/modules/database_statement_monitoring_test/src/pgsql/Connection.php
+++ b/modules/migrate_drupal_ui/tests/src/Functional/d6/files/core/modules/system/tests/modules/database_statement_monitoring_test/src/pgsql/Connection.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Drupal\database_statement_monitoring_test\pgsql;
+
+use Drupal\Core\Database\Driver\pgsql\Connection as BaseConnection;
+use Drupal\database_statement_monitoring_test\LoggedStatementsTrait;
+
+/**
+ * PostgreSQL Connection class that can log executed queries.
+ */
+class Connection extends BaseConnection {
+  use LoggedStatementsTrait;
+
+}

--- a/modules/migrate_drupal_ui/tests/src/Functional/d6/files/core/modules/system/tests/modules/database_statement_monitoring_test/src/sqlite/Connection.php
+++ b/modules/migrate_drupal_ui/tests/src/Functional/d6/files/core/modules/system/tests/modules/database_statement_monitoring_test/src/sqlite/Connection.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Drupal\database_statement_monitoring_test\sqlite;
+
+use Drupal\Core\Database\Driver\sqlite\Connection as BaseConnection;
+use Drupal\database_statement_monitoring_test\LoggedStatementsTrait;
+
+/**
+ * SQlite Connection class that can log executed queries.
+ */
+class Connection extends BaseConnection {
+  use LoggedStatementsTrait;
+
+}

--- a/modules/migrate_drupal_ui/tests/src/Functional/d6/files/core/modules/system/tests/modules/delay_cache_tags_invalidation/delay_cache_tags_invalidation.info.yml
+++ b/modules/migrate_drupal_ui/tests/src/Functional/d6/files/core/modules/system/tests/modules/delay_cache_tags_invalidation/delay_cache_tags_invalidation.info.yml
@@ -1,0 +1,5 @@
+name: 'Delay Cache Tags Invalidation Test'
+type: module
+core: 8.x
+package: Testing
+version: VERSION

--- a/modules/migrate_drupal_ui/tests/src/Functional/d6/files/core/modules/system/tests/modules/delay_cache_tags_invalidation/delay_cache_tags_invalidation.module
+++ b/modules/migrate_drupal_ui/tests/src/Functional/d6/files/core/modules/system/tests/modules/delay_cache_tags_invalidation/delay_cache_tags_invalidation.module
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @file
+ * Functions to test delayed cache tags invalidation.
+ */
+
+use Drupal\Core\Cache\Cache;
+use Drupal\entity_test\Entity\EntityTest;
+use Drupal\user\Entity\User;
+use Drupal\user\UserInterface;
+
+/**
+ * Implements hook_ENTITY_TYPE_insert().
+ */
+function delay_cache_tags_invalidation_entity_test_insert(EntityTest $entity) {
+  if (\Drupal::state()->get('delay_cache_tags_invalidation_exception')) {
+    throw new \Exception('Abort entity save to trigger transaction rollback.');
+  }
+
+  // Read the pre-transaction cache writes.
+  // @see \Drupal\KernelTests\Core\Cache\EndOfTransactionQueriesTest::testEntitySave()
+  \Drupal::state()->set(__FUNCTION__ . '__pretransaction_foobar', \Drupal::cache()->get('test_cache_pretransaction_foobar'));
+  \Drupal::state()->set(__FUNCTION__ . '__pretransaction_entity_test_list', \Drupal::cache()->get('test_cache_pretransaction_entity_test_list'));
+
+  // Write during the transaction.
+  \Drupal::cache()->set(__FUNCTION__ . '__during_transaction_foobar', 'something', Cache::PERMANENT, ['foobar']);
+  \Drupal::cache()->set(__FUNCTION__ . '__during_transaction_entity_test_list', 'something', Cache::PERMANENT, ['entity_test_list']);
+
+  // Trigger a nested entity save and hence a nested transaction.
+  User::create([
+    'name' => 'johndoe',
+    'status' => 1,
+  ])->save();
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_insert().
+ */
+function delay_cache_tags_invalidation_user_insert(UserInterface $entity) {
+  if ($entity->getAccountName() === 'johndoe') {
+    // Read the in-transaction cache writes.
+    // @see  delay_cache_tags_invalidation_entity_test_insert()
+    \Drupal::state()->set(__FUNCTION__ . '__during_transaction_foobar', \Drupal::cache()->get('delay_cache_tags_invalidation_entity_test_insert__during_transaction_foobar'));
+    \Drupal::state()->set(__FUNCTION__ . '__during_transaction_entity_test_list', \Drupal::cache()->get('delay_cache_tags_invalidation_entity_test_insert__during_transaction_entity_test_list'));
+  }
+}

--- a/tests/Drupal/KernelTests/Core/Cache/EndOfTransactionQueriesTest.php
+++ b/tests/Drupal/KernelTests/Core/Cache/EndOfTransactionQueriesTest.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace Drupal\KernelTests\Core\Cache;
+
+use Drupal\Core\Cache\Cache;
+use Drupal\Core\Cache\DatabaseBackendFactory;
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\entity_test\Entity\EntityTest;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\user\Entity\User;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Tests that cache tag invalidation queries are delayed to the end of transactions.
+ *
+ * @group Cache
+ */
+class EndOfTransactionQueriesTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'delay_cache_tags_invalidation',
+    'entity_test',
+    'system',
+    'user',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    if (!class_exists($this->getDatabaseConnectionInfo()['default']['namespace'] . '\Connection')) {
+      $this->markTestSkipped(sprintf('No logging override exists for the %s database driver. Create it, subclass this test class and override ::getDatabaseConnectionInfo().', $this->getDatabaseConnectionInfo()['default']['driver']));
+    }
+
+    parent::setUp();
+
+    $this->installSchema('system', 'sequences');
+    $this->installEntitySchema('entity_test');
+    $this->installEntitySchema('user');
+
+    // Ensure the cachetags table already exists.
+    Cache::invalidateTags([$this->randomString()]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function register(ContainerBuilder $container) {
+    parent::register($container);
+
+    // Register a database cache backend rather than memory-based.
+    $container->register('cache_factory', DatabaseBackendFactory::class)
+      ->addArgument(new Reference('database'))
+      ->addArgument(new Reference('cache_tags.invalidator.checksum'))
+      ->addArgument(new Reference('settings'));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function testEntitySave() {
+    \Drupal::cache()->set('test_cache_pretransaction_foobar', 'something', Cache::PERMANENT, ['foobar']);
+    \Drupal::cache()->set('test_cache_pretransaction_entity_test_list', 'something', Cache::PERMANENT, ['entity_test_list']);
+
+    $entity = EntityTest::create(['name' => $this->randomString()]);
+    \Drupal::database()->resetLoggedStatements();
+
+    $entity->save();
+
+    $executed_statements = \Drupal::database()->getLoggedStatements();
+    $last_statement_index = max(array_keys($executed_statements));
+
+    $cachetag_statements = array_keys($this->getStatementsForTable(\Drupal::database()->getLoggedStatements(), 'cachetags'));
+    $this->assertSame($last_statement_index - count($cachetag_statements) + 1, min($cachetag_statements), 'All of the last queries in the transaction are for the "cachetags" table.');
+
+    // Verify that a nested entity save occurred.
+    $this->assertSame('johndoe', User::load(1)->getAccountName());
+
+    // Cache reads occurring during a transaction that DO NOT depend on
+    // invalidated cache tags result in cache HITs. Similarly, cache writes that
+    // DO NOT depend on invalidated cache tags DO get written. Of course, if we
+    // read either one now, outside of the context of the transaction, we expect
+    // the same.
+    $this->assertNotEmpty(\Drupal::state()->get('delay_cache_tags_invalidation_entity_test_insert__pretransaction_foobar'));
+    $this->assertNotEmpty(\Drupal::cache()->get('delay_cache_tags_invalidation_entity_test_insert__during_transaction_foobar'));
+    $this->assertNotEmpty(\Drupal::state()->get('delay_cache_tags_invalidation_user_insert__during_transaction_foobar'));
+    $this->assertNotEmpty(\Drupal::cache()->get('test_cache_pretransaction_foobar'));
+
+    // Cache reads occurring during a transaction that DO depend on invalidated
+    // cache tags result in cache MISSes. Similarly, cache writes that DO depend
+    // on invalidated cache tags DO NOT get written. Of course, if we read
+    // either one now, outside of the context of the transaction, we expect the
+    // same.
+    $this->assertFalse(\Drupal::state()->get('delay_cache_tags_invalidation_entity_test_insert__pretransaction_entity_test_list'));
+    $this->assertFalse(\Drupal::cache()->get('delay_cache_tags_invalidation_entity_test_insert__during_transaction_entity_test_list'));
+    $this->assertFalse(\Drupal::state()->get('delay_cache_tags_invalidation_user_insert__during_transaction_entity_test_list'));
+    $this->assertFalse(\Drupal::cache()->get('test_cache_pretransaction_entity_test_list'));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function testEntitySaveRollback() {
+    \Drupal::cache()
+      ->set('test_cache_pretransaction_entity_test_list', 'something', Cache::PERMANENT, ['entity_test_list']);
+    \Drupal::cache()
+      ->set('test_cache_pretransaction_user_list', 'something', Cache::PERMANENT, ['user_list']);
+
+    \Drupal::state()->set('delay_cache_tags_invalidation_exception', TRUE);
+
+    try {
+      EntityTest::create(['name' => $this->randomString()])->save();
+      $this->fail('Exception not thrown');
+    }
+    catch (\Exception $e) {
+      $this->assertEquals('Abort entity save to trigger transaction rollback.', $e->getMessage());
+    }
+
+    // The cache has not been invalidated.
+    $this->assertNotEmpty(\Drupal::cache()->get('test_cache_pretransaction_entity_test_list'));
+    $this->assertNotEmpty(\Drupal::cache()->get('test_cache_pretransaction_user_list'));
+
+    // Save a user, that should invalidate the cache tagged with user_list but
+    // not the one with entity_test_list.
+    User::create([
+      'name' => 'johndoe',
+      'status' => 1,
+    ])->save();
+
+    $this->assertNotEmpty(\Drupal::cache()->get('test_cache_pretransaction_entity_test_list'));
+    $this->assertFalse(\Drupal::cache()->get('test_cache_pretransaction_user_list'));
+  }
+
+  /**
+   * Filters statements by table name.
+   *
+   * @param string[] $statements
+   *   A list of query statements.
+   * @param $table_name
+   *   The name of the table to filter by.
+   *
+   * @return string[]
+   *   Filtered statement list.
+   */
+  protected function getStatementsForTable(array $statements, $table_name) {
+    $tables = array_filter(array_map([$this, 'statementToTableName'], $statements));
+    return array_filter($tables, function ($table_for_statement) use ($table_name) {
+      return $table_for_statement === $table_name;
+    });
+  }
+
+  /**
+   * Returns the table name for a statement.
+   *
+   * @param string $statement
+   *   The query statement.
+   *
+   * @return string|null
+   *   The name of the table or NULL if none was found.
+   */
+  protected static function statementToTableName($statement) {
+    if (preg_match('/.*\{([^\}]+)\}.*/', $statement, $matches)) {
+      return $matches[1];
+    }
+    else {
+      return NULL;
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getDatabaseConnectionInfo() {
+    $info = parent::getDatabaseConnectionInfo();
+    // Override default database driver to one that does logging. Third-party
+    // (non-core) database drivers can achieve the same test coverage by
+    // subclassing this test class and overriding only this method.
+    // @see \Drupal\database_statement_monitoring_test\LoggedStatementsTrait
+    // @see \Drupal\database_statement_monitoring_test\mysql\Connection
+    // @see \Drupal\database_statement_monitoring_test\pgsql\Connection
+    // @see \Drupal\database_statement_monitoring_test\sqlite\Connection
+    $info['default']['namespace'] = '\Drupal\database_statement_monitoring_test\\' . $info['default']['driver'];
+    return $info;
+  }
+
+}


### PR DESCRIPTION
Applies a patch to Drupal core to support cache operations at the end of a database transaction, resolving a race condition on node save.

https://www.drupal.org/project/drupal/issues/2966607#comment-13253493